### PR TITLE
Add changelog and install notes about image tags

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,22 @@ description: History of notable updates and changes to CodeGate
 sidebar_position: 20
 ---
 
+:::info
+
+Major features and changes are noted here. To review all updates, see the
+[GitHub Releases page](https://github.com/stacklok/codegate/releases).
+
+:::
+
+- **Semantic versioning for container image** - 8 Jan, 2025\
+  Starting with v0.1.4, the CodeGate container image is published with semantic
+  version tags corresponding to
+  [GitHub releases](https://github.com/stacklok/codegate/releases). You can
+  optionally pull using the major (`v0`), minor (`v0.1`), or patch version
+  (`v0.1.4`) to explicitly control the version you're running. \
+  CodeGate is evolving quickly, so we still recommend pulling the `latest` tag
+  so you don't miss out on new features and updates to package risk data.
+
 - **UI port change** - 7 Jan, 2025\
   The internal port for the dashboard UI has changed from 80 to 9090 to resolve
   a permissions issue for Linux users.

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -48,7 +48,7 @@ Run with minimal functionality for use with **Continue**:
 docker run -d -p 8989:8989 -p 9090:9090 --restart unless-stopped ghcr.io/stacklok/codegate:latest
 ```
 
-Mount a **persistent volume** to the container (see
+**Mount a persistent volume** to the container (see
 [Persisting dashboard data](./dashboard.md#persisting-dashboard-data)):
 
 ```bash
@@ -61,6 +61,16 @@ docker run --name codegate -d -p 8989:8989 -p 9090:9090 --mount type=volume,src=
 ```bash
 docker run --name codegate -d -p 8989:8989 -p 9090:9090 -p 8990:8990 --mount type=volume,src=codegate_volume,dst=/app/codegate_volume --restart unless-stopped ghcr.io/stacklok/codegate:latest
 ```
+
+**Install a specific version:** starting with v0.1.4 you can optionally run a
+specific version of CodeGate using sematic version tags:
+
+- Patch version: `ghcr.io/stacklok/codegate:v0.1.4` (exact)
+- Minor version: `ghcr.io/stacklok/codegate:v0.1` (latest v0.1.x release)
+- Major version: `ghcr.io/stacklok/codegate:v0` (latest v0.x.x release)
+
+See the [GitHub releases](https://github.com/stacklok/codegate/releases) page
+for available versions.
 
 :::tip
 


### PR DESCRIPTION
Now that we have the semver tags being published, adding notes to the install how-to and the changelog.