### PR TITLE
Disable MD034 / no-bare-urls

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -10,6 +10,7 @@
     "code_blocks": false,
     "tables": false
   },
+  "no-bare-urls": false,
   "hr-style": {
     "style": "---"
   },

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,23 +1,4 @@
 {
-  "heading-style": {
-    "style": "atx"
-  },
-  "ul-style": {
-    "style": "dash"
-  },
-  "line-length": {
-    "line_length": 80,
-    "code_blocks": false,
-    "tables": false
-  },
-  "no-bare-urls": false,
-  "hr-style": {
-    "style": "---"
-  },
-  "proper-names": {
-    "names": ["CodeGate", "Copilot", "GitHub"],
-    "code_blocks": false
-  },
   "code-block-style": {
     "style": "fenced"
   },
@@ -27,10 +8,29 @@
   "emphasis-style": {
     "style": "underscore"
   },
+  "heading-style": {
+    "style": "atx"
+  },
+  "hr-style": {
+    "style": "---"
+  },
+  "line-length": {
+    "code_blocks": false,
+    "line_length": 80,
+    "tables": false
+  },
+  "no-bare-urls": false,
+  "proper-names": {
+    "code_blocks": false,
+    "names": ["CodeGate", "Copilot", "GitHub"]
+  },
   "strong-style": {
     "style": "asterisk"
   },
   "table-pipe-style": {
     "style": "leading_and_trailing"
+  },
+  "ul-style": {
+    "style": "dash"
   }
 }


### PR DESCRIPTION
While we should avoid bare URLs, the fix for this rule (surrounding the URL with <>) breaks rendering, since Docusaurus currently runs all files through the MDX engine and a < is interpreted as a JSX tag.

This PR also sorts the .markdownlint.json config alphabetically by the alias names instead of by the rule ID.