### PR TITLE
Minor docs updates for sample prompts

### DIFF
--- a/docs/how-to/use-with-aider.mdx
+++ b/docs/how-to/use-with-aider.mdx
@@ -34,7 +34,7 @@ To configure Aider to send requests through CodeGate:
 
 To verify that you've successfully connected Aider to CodeGate, type
 `/ask codegate-version` into the Aider chat in your terminal. You should receive
-a response like "CodeGate version 0.1.0":
+a response like "CodeGate version 0.1.7":
 
 ## Next steps
 

--- a/docs/how-to/use-with-continue.mdx
+++ b/docs/how-to/use-with-continue.mdx
@@ -380,10 +380,10 @@ Otherwise, remove the `apiKey` parameter from both sections.
 
 To verify that you've successfully connected Continue to CodeGate, open the
 Continue chat and type `codegate-version`. You should receive a response like
-"CodeGate version 0.1.0":
+"CodeGate version 0.1.7":
 
 <ThemedImage
-  alt='Continue extension settings'
+  alt='Verify Continue integration'
   sources={{
     light: useBaseUrl('/img/how-to/continue-codegate-version-light.webp'),
     dark: useBaseUrl('/img/how-to/continue-codegate-version-dark.webp'),
@@ -401,17 +401,15 @@ CodeGate responds with a warning and a link to the Stacklok Insight report about
 this package:
 
 ```plain title="Continue chat"
-Warning: CodeGate detected one or more malicious or archived packages.
+Warning: CodeGate detected one or more malicious, deprecated or archived packages.
 
-Package: https://insight.stacklok.com/pypi/invokehttp
+ • invokehttp: https://www.insight.stacklok.com/report/pypi/invokehttp
 
-CodeGate Security Analysis
+The `invokehttp` package from PyPI has been identified as malicious and should
+not be used. Please avoid using this package and consider using a trusted
+alternative such as `requests` for making HTTP requests in Python.
 
-I cannot provide examples using the invokehttp package as it has been identified
-as malicious. Using this package could compromise your system's security.
-
-Instead, I recommend using well-established, secure alternatives for HTTP
-requests in Python:
+Here is an example of how to use the `requests` package:
 
 ...
 ```

--- a/docs/how-to/use-with-copilot.mdx
+++ b/docs/how-to/use-with-copilot.mdx
@@ -233,16 +233,9 @@ Support for JetBrains is [coming soon](https://github.com/stacklok/codegate/issu
 
 ## Verify configuration
 
-To verify that CodeGate is receiving Copilot traffic as expected, open the
-Copilot chat and type `What do you know about CodeGate?`. You should receive a
-response that starts like this:
-
-```plain title="Copilot chat"
-CodeGate is a security-focused AI assistant designed to help with software
-security, package analysis, and providing guidance on secure coding practices.
-
-...
-```
+To verify that you've successfully connected Copilot to CodeGate, open the
+Copilot chat and type `codegate-version`. You should receive a response like
+"CodeGate version 0.1.7".
 
 Try asking CodeGate about a known malicious Python package:
 
@@ -254,17 +247,15 @@ CodeGate responds with a warning and a link to the Stacklok Insight report about
 this package:
 
 ```plain title="Copilot chat"
-Warning: CodeGate detected one or more malicious or archived packages.
+Warning: CodeGate detected one or more malicious, deprecated or archived packages.
 
-Package: https://insight.stacklok.com/pypi/invokehttp
+ • invokehttp: https://www.insight.stacklok.com/report/pypi/invokehttp
 
-CodeGate Security Analysis
+The `invokehttp` package from PyPI has been identified as malicious and should
+not be used. Please avoid using this package and consider using a trusted
+alternative such as `requests` for making HTTP requests in Python.
 
-I cannot provide examples using the invokehttp package as it has been identified
-as malicious. Using this package could compromise your system's security.
-
-Instead, I recommend using well-established, secure alternatives for HTTP
-requests in Python:
+Here is an example of how to use the `requests` package:
 
 ...
 ```

--- a/docs/quickstart-copilot.mdx
+++ b/docs/quickstart-copilot.mdx
@@ -94,6 +94,9 @@ Add the following settings to your configuration:
 }
 ```
 
+Enter `codegate-version` in the Copilot chat to confirm that CodeGate is
+intercepting Copilot traffic. CodeGate responds with its version number.
+
 ## Explore CodeGate's key features
 
 To learn more about CodeGate's capabilities, clone the demo repository to a


### PR DESCRIPTION
A few minor touch-ups:

- The Copilot integration now supports the codegate-version prompt, replacing the previous verification step.
- Refresh the example responses about malicious packages with current language.