### PR TITLE
Update codegate-version command

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
-  "*.{js,jsx,ts,tsx,mjs,cjs}": ["npx prettier --write", "npx eslint --fix"],
+  "*.{js,jsx,ts,tsx,mjs,cjs,mdx}": ["npx prettier --write", "npx eslint --fix"],
   "*.md": ["npx prettier --write", "npx markdownlint-cli2 --fix"],
-  "*.css": ["npx prettier --write"]
+  "*.{css,json,jsonc,yaml,yml}": ["npx prettier --write"]
 }

--- a/docs/how-to/use-with-aider.mdx
+++ b/docs/how-to/use-with-aider.mdx
@@ -33,7 +33,7 @@ To configure Aider to send requests through CodeGate:
 ## Verify configuration
 
 To verify that you've successfully connected Aider to CodeGate, type
-`/ask codegate-version` into the Aider chat in your terminal. You should receive
+`/ask codegate version` into the Aider chat in your terminal. You should receive
 a response like "CodeGate version 0.1.7":
 
 ## Next steps

--- a/docs/how-to/use-with-continue.mdx
+++ b/docs/how-to/use-with-continue.mdx
@@ -379,7 +379,7 @@ Otherwise, remove the `apiKey` parameter from both sections.
 ## Verify configuration
 
 To verify that you've successfully connected Continue to CodeGate, open the
-Continue chat and type `codegate-version`. You should receive a response like
+Continue chat and type `codegate version`. You should receive a response like
 "CodeGate version 0.1.7":
 
 <ThemedImage

--- a/docs/how-to/use-with-copilot.mdx
+++ b/docs/how-to/use-with-copilot.mdx
@@ -234,7 +234,7 @@ Support for JetBrains is [coming soon](https://github.com/stacklok/codegate/issu
 ## Verify configuration
 
 To verify that you've successfully connected Copilot to CodeGate, open the
-Copilot chat and type `codegate-version`. You should receive a response like
+Copilot chat and type `codegate version`. You should receive a response like
 "CodeGate version 0.1.7".
 
 Try asking CodeGate about a known malicious Python package:

--- a/docs/quickstart-continue.mdx
+++ b/docs/quickstart-continue.mdx
@@ -139,7 +139,7 @@ panel.
   width={'650px'}
 />
 
-Enter `codegate-version` in the chat box to confirm that Continue is
+Enter `codegate version` in the chat box to confirm that Continue is
 communicating with CodeGate. CodeGate responds with its version number.
 
 ## Explore CodeGate's features

--- a/docs/quickstart-copilot.mdx
+++ b/docs/quickstart-copilot.mdx
@@ -94,7 +94,7 @@ Add the following settings to your configuration:
 }
 ```
 
-Enter `codegate-version` in the Copilot chat to confirm that CodeGate is
+Enter `codegate version` in the Copilot chat to confirm that CodeGate is
 intercepting Copilot traffic. CodeGate responds with its version number.
 
 ## Explore CodeGate's key features


### PR DESCRIPTION
On the next release, `codegate-version` will change to `codegate version`. Merge this once release goes out