### PR TITLE
Open code in codegate-demonstration folder

### DIFF
--- a/docs/quickstart-continue.mdx
+++ b/docs/quickstart-continue.mdx
@@ -164,7 +164,7 @@ terminal:
 
 ```bash
 cd codegate-demonstration
-code ./codegate-demonstration
+code .
 ```
 
 ### Protect your secrets

--- a/docs/quickstart-copilot.mdx
+++ b/docs/quickstart-copilot.mdx
@@ -119,7 +119,7 @@ terminal:
 
 ```bash
 cd codegate-demonstration
-code ./codegate-demonstration
+code .
 ```
 
 ### Protect your secrets


### PR DESCRIPTION
The prior command is `cd codegate-demonstration`; the next command should be to open `code` in the current directory.