### PR TITLE
Fix aider naming style

### DIFF
--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -210,6 +210,9 @@ sentence.
 
 ### Products/brands
 
+**aider** - an open source AI pair programmer in your terminal. It's written
+lowercase unless it starts a sentence.
+
 **Continue** - an open source AI coding assistant for IDEs that connects to many
 model providers. It's written as just "Continue" (not "Continue.dev", which is
 their website).

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -19,7 +19,7 @@ Related: [Upgrade CodeGate](../how-to/install.md#upgrade-codegate)
   [Workspaces](../features/workspaces.mdx).
 
 - **Aider support** - 13 Jan, 2025\
-  CodeGate version 0.1.6 adds support for [Aider](https://aider.chat/), an LLM
+  CodeGate version 0.1.6 adds support for [aider](https://aider.chat/), an AI
   pair programmer in your terminal. See the
   [how-to guide](../how-to/use-with-aider.mdx) to learn more.
 

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -42,7 +42,7 @@ application settings, see [Configure CodeGate](./configure.md)
 
 ### Alternative run commands {#examples}
 
-Run with minimal functionality for use with **Continue** or **Aider**:
+Run with minimal functionality for use with **Continue** or **aider**:
 
 ```bash
 docker run -d -p 8989:8989 -p 9090:9090 --restart unless-stopped ghcr.io/stacklok/codegate:latest
@@ -151,8 +151,8 @@ persistent volume.
 Now that CodeGate is running, proceed to configure your IDE integration.
 
 - [Use CodeGate with GitHub Copilot](./use-with-copilot.mdx)
+- [Use CodeGate with aider](./use-with-aider.mdx)
 - [Use CodeGate with Continue](./use-with-continue.mdx)
-- [Use CodeGate with Aider](./use-with-aider.mdx)
 
 ## Remove CodeGate
 
@@ -160,5 +160,5 @@ If you decide to stop using CodeGate, follow the removal steps for your IDE
 integration:
 
 - [Remove CodeGate - GitHub Copilot](./use-with-copilot.mdx#remove-codegate)
+- [Remove CodeGate - aider](./use-with-aider.mdx#remove-codegate)
 - [Remove CodeGate - Continue](./use-with-continue.mdx#remove-codegate)
-- [Remove CodeGate - Aider](./use-with-aider.mdx#remove-codegate)

--- a/docs/how-to/use-with-aider.mdx
+++ b/docs/how-to/use-with-aider.mdx
@@ -1,7 +1,7 @@
 ---
-title: Use CodeGate with Aider
-description: Configure the Aider for CodeGate
-sidebar_label: Use with Aider
+title: Use CodeGate with aider
+description: Configure aider for CodeGate
+sidebar_label: Use with aider
 sidebar_position: 90
 ---
 
@@ -10,7 +10,7 @@ import AiderProviders from '../partials/_aider-providers.mdx';
 [Aider](https://aider.chat/) is an open source AI coding assistant that lets you
 pair program with LLMs in your terminal.
 
-CodeGate works with the following AI model providers through Aider:
+CodeGate works with the following AI model providers through aider:
 
 - Local / self-managed:
   - [Ollama](https://ollama.com/)
@@ -19,21 +19,21 @@ CodeGate works with the following AI model providers through Aider:
 
 :::note
 
-This guide assumes you have already installed Aider using their
+This guide assumes you have already installed aider using their
 [installation instructions](https://aider.chat/docs/install.html).
 
 :::
 
-## Configure Aider to use CodeGate
+## Configure aider to use CodeGate
 
-To configure Aider to send requests through CodeGate:
+To configure aider to send requests through CodeGate:
 
 <AiderProviders />
 
 ## Verify configuration
 
-To verify that you've successfully connected Aider to CodeGate, type
-`/ask codegate version` into the Aider chat in your terminal. You should receive
+To verify that you've successfully connected aider to CodeGate, type
+`/ask codegate version` into the aider chat in your terminal. You should receive
 a response like "CodeGate version 0.1.7":
 
 ## Next steps
@@ -48,7 +48,7 @@ Learn more about CodeGate's features:
 If you decide to stop using CodeGate, follow these steps to remove it and revert
 your environment.
 
-1. Stop Aider and unset the environment variables you set during the
+1. Quit aider and unset the environment variables you set during the
    configuration process:
 
    **OpenAI:** `unset OPENAI_API_BASE` (macOS/Linux) or
@@ -56,8 +56,6 @@ your environment.
 
    **Ollama:** `unset OLLAMA_API_BASE` (macOS/Linux) or
    `setx OLLAMA_API_BASE ""` (Windows)
-
-1. Re-launch Aider.
 
 1. Stop and remove the CodeGate container:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,10 @@ sidebar_position: 1
 
 ## What is CodeGate?
 
-CodeGate is local prompt gateway that sits between your AI coding assistant and
-LLM to enhance privacy and security. CodeGate performs code security reviews,
-identifies vulnerabilities in package dependencies, and prevents sensitive data
-like secrets from being shared with AI models.
+CodeGate is a local prompt gateway that sits between your AI coding assistant
+and LLM to enhance privacy and security. CodeGate performs code security
+reviews, identifies vulnerabilities in package dependencies, and prevents
+sensitive data like secrets from being shared with AI models.
 
 ```mermaid
 sequenceDiagram
@@ -54,7 +54,7 @@ AI coding assistants / IDEs:
     - Anthropic
     - OpenAI
 
-**[Aider](./how-to/use-with-aider.mdx)** with Ollama and OpenAI
+- **[Aider](./how-to/use-with-aider.mdx)** with Ollama and OpenAI
 
 As the project evolves, we plan to add support for more IDE assistants and AI
 model providers.

--- a/docs/partials/_aider-providers.mdx
+++ b/docs/partials/_aider-providers.mdx
@@ -75,7 +75,7 @@ export OLLAMA_API_BASE=http://localhost:8989/ollama
 :::note
 
 To persist this setting, add it to your shell profile (e.g., `~/.bashrc` or
-`~/.zshrc`) or use one of's other
+`~/.zshrc`) or use one of's aider's other
 [supported configuration methods](https://aider.chat/docs/config/api-keys.html).
 
 :::
@@ -96,7 +96,7 @@ Restart your shell after running `setx`.
 </TabItem>
 </Tabs>
 
-Then run:
+Then run aider:
 
 ```bash
 aider --model ollama_chat/<MODEL_NAME>
@@ -114,7 +114,7 @@ CPU cores and 16GB of RAM. If you have more compute resources available, our
 experimentation shows that larger models do yield better results.
 
 For more information, see the
-[ docs for connecting to Ollama](https://aider.chat/docs/llms/ollama.html).
+[aider docs for connecting to Ollama](https://aider.chat/docs/llms/ollama.html).
 
 </TabItem>
 </Tabs>

--- a/docs/partials/_aider-providers.mdx
+++ b/docs/partials/_aider-providers.mdx
@@ -6,8 +6,8 @@ import TabItem from '@theme/TabItem';
 
 You need an [OpenAI API](https://openai.com/api/) account to use this provider.
 
-Before you run Aider, set environment variables for your API key and to set the
-API base URL to CodeGate's API port. Alternately, use one of Aider's other
+Before you run aider, set environment variables for your API key and to set the
+API base URL to CodeGate's API port. Alternately, use one of aider's other
 [supported configuration methods](https://aider.chat/docs/config/api-keys.html)
 to set the corresponding values.
 
@@ -47,7 +47,7 @@ Replace `<YOUR_API_KEY>` with your
 [OpenAI API key](https://platform.openai.com/api-keys).
 
 Then run `aider` as normal. For more information, see the
-[Aider docs for connecting to OpenAI](https://aider.chat/docs/llms/openai.html).
+[aider docs for connecting to OpenAI](https://aider.chat/docs/llms/openai.html).
 
 </TabItem>
 <TabItem value="ollama" label="Ollama">
@@ -60,8 +60,8 @@ changed the default Ollama server port or to connect to a remote Ollama
 instance, launch CodeGate with the `CODEGATE_OLLAMA_URL` environment variable
 set to the correct URL. See [Configure CodeGate](/how-to/configure.md).
 
-Before you run Aider, set the Ollama base URL to CodeGate's API port using an
-environment variable. Alternately, use one of Aider's other
+Before you run aider, set the Ollama base URL to CodeGate's API port using an
+environment variable. Alternately, use one of aider's other
 [supported configuration methods](https://aider.chat/docs/config/api-keys.html)
 to set the corresponding values.
 
@@ -75,7 +75,7 @@ export OLLAMA_API_BASE=http://localhost:8989/ollama
 :::note
 
 To persist this setting, add it to your shell profile (e.g., `~/.bashrc` or
-`~/.zshrc`) or use one of Aider's other
+`~/.zshrc`) or use one of's other
 [supported configuration methods](https://aider.chat/docs/config/api-keys.html).
 
 :::
@@ -96,7 +96,7 @@ Restart your shell after running `setx`.
 </TabItem>
 </Tabs>
 
-Then run Aider:
+Then run:
 
 ```bash
 aider --model ollama_chat/<MODEL_NAME>
@@ -114,7 +114,7 @@ CPU cores and 16GB of RAM. If you have more compute resources available, our
 experimentation shows that larger models do yield better results.
 
 For more information, see the
-[Aider docs for connecting to Ollama](https://aider.chat/docs/llms/ollama.html).
+[ docs for connecting to Ollama](https://aider.chat/docs/llms/ollama.html).
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Aider is written lowercase unless it starts a setence (like this one :smile:). Fixing docs to reflect that.