### PR TITLE
Fix protocol for Cline Anthropic integration

### DIFF
--- a/docs/partials/_cline-providers.mdx
+++ b/docs/partials/_cline-providers.mdx
@@ -16,7 +16,7 @@ Anthropic API key, and choose your preferred model (we recommend
 `claude-3-5-sonnet-<latest>`).
 
 To enable CodeGate, enable **Use custom base URL** and enter
-`https://localhost:8989/anthropic`.
+`http://localhost:8989/anthropic`.
 
 <ThemedImage
   alt='Cline settings for Anthropic'


### PR DESCRIPTION
See the original page here, specifically the box for the Anthropic provider configuration: https://docs.codegate.ai/integrations/cline?provider=anthropic

In the screenshot which shows the configuration needed for Codegate, the URL uses http whereas the instructions use https. Since port 8989 appears to be serving http traffic, it seems like http is the correct one.