### PR TITLE
Simplify container restart command

### DIFF
--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -147,8 +147,7 @@ docker pull ghcr.io/stacklok/codegate:latest
 Stop and remove the current container:
 
 ```bash
-docker stop codegate
-docker rm codegate
+docker rm --force codegate
 ```
 
 Finally, launch the new version using the
@@ -171,6 +170,6 @@ If you decide to stop using CodeGate, follow the removal steps for your
 container and volume:
 
 ```bash
-docker stop codegate && docker rm codegate
+docker rm -f codegate
 docker volume rm codegate_volume
 ```

--- a/docs/integrations/aider.mdx
+++ b/docs/integrations/aider.mdx
@@ -60,7 +60,7 @@ your environment.
 1. Stop and remove the CodeGate container:
 
    ```bash
-   docker stop codegate && docker rm codegate
+   docker rm -f codegate
    ```
 
 1. If you launched CodeGate with a persistent volume, delete it to remove the

--- a/docs/integrations/cline.mdx
+++ b/docs/integrations/cline.mdx
@@ -117,7 +117,7 @@ your environment.
 1. Stop and remove the CodeGate container:
 
    ```bash
-   docker stop codegate && docker rm codegate
+   docker rm -f codegate
    ```
 
 1. If you launched CodeGate with a persistent volume, delete it to remove the

--- a/docs/integrations/continue.mdx
+++ b/docs/integrations/continue.mdx
@@ -433,7 +433,7 @@ your environment.
 1. Stop and remove the CodeGate container:
 
    ```bash
-   docker stop codegate && docker rm codegate
+   docker rm -f codegate
    ```
 
 1. If you launched CodeGate with a persistent volume, delete it to remove the

--- a/docs/integrations/copilot.mdx
+++ b/docs/integrations/copilot.mdx
@@ -47,7 +47,7 @@ flowchart LR
 
 Several additional Docker parameters are required for Copilot support when you
 launch CodeGate. If already have CodeGate running, remove the existing container
-first with `docker stop codegate && docker rm codegate`.
+first with `docker rm -f codegate`.
 
 1. The CodeGate HTTP proxy port (8990) must be mapped to your host along with
    the CodeGate API and UI ports.\
@@ -289,7 +289,7 @@ import RemoveCert from '../partials/_remove-cert.mdx';
 1. Stop and remove the CodeGate container:
 
    ```bash
-   docker stop codegate && docker rm codegate
+   docker rm -f codegate
    ```
 
 1. Delete the persistent volume:

--- a/docs/integrations/open-interpreter.mdx
+++ b/docs/integrations/open-interpreter.mdx
@@ -83,7 +83,7 @@ your environment.
 1. Stop and remove the CodeGate container:
 
    ```bash
-   docker stop codegate && docker rm codegate
+   docker rm -f codegate
    ```
 
 1. If you launched CodeGate with a persistent volume, delete it to remove the

--- a/docs/quickstart-continue.mdx
+++ b/docs/quickstart-continue.mdx
@@ -278,7 +278,7 @@ stop using it, follow these steps to clean up your environment.
 1. Stop and remove the CodeGate container:
 
    ```bash
-   docker stop codegate && docker rm codegate
+   docker rm -f codegate
    ```
 
 2. Remove the `apiBase` configuration entries from your Continue configuration

--- a/docs/quickstart-copilot.mdx
+++ b/docs/quickstart-copilot.mdx
@@ -263,7 +263,7 @@ import RemoveCert from './partials/_remove-cert.mdx';
 1. Stop and remove the CodeGate container:
 
    ```bash
-   docker stop codegate && docker rm codegate
+   docker rm -f codegate
    ```
 
 1. Delete the persistent volume:


### PR DESCRIPTION
I was annoyed that it was 4 commands to upgrade codegate; this reduces it to 3 commands.  It might be possible to make an upgrade button if we can plumb through the docker socket into the container...
