### PR TITLE
fix: adds note for copilot docs

### DIFF
--- a/docs/integrations/copilot.mdx
+++ b/docs/integrations/copilot.mdx
@@ -231,8 +231,8 @@ Append the following settings to your configuration:
 ## Verify configuration
 
 To verify that you've successfully connected Copilot to CodeGate, open the
-Copilot chat and type `codegate version`. You should receive a response like
-"CodeGate version 0.1.13".
+Copilot Chat (not Copilot Edits) and type `codegate version`. You should receive
+a response like "CodeGate version 0.1.13".
 
 :::note
 

--- a/docs/integrations/copilot.mdx
+++ b/docs/integrations/copilot.mdx
@@ -236,7 +236,11 @@ a response like "CodeGate version 0.1.13".
 
 :::note
 
-Make sure you have no open files when running the `codegate version` command, otherwise Copilot will make comments based on the file you have open.
+There is a [known issue](https://github.com/stacklok/codegate/issues/1061) with
+`codegate` commands in Copilot chat if you have a file included in the context.
+Close all open files or use the eye icon in the chat input to disable the
+current file context, otherwise Copilot responds based on the file you have open
+instead of returning the command result.
 
 :::
 

--- a/docs/integrations/copilot.mdx
+++ b/docs/integrations/copilot.mdx
@@ -234,6 +234,12 @@ To verify that you've successfully connected Copilot to CodeGate, open the
 Copilot chat and type `codegate version`. You should receive a response like
 "CodeGate version 0.1.13".
 
+:::note
+
+Make sure you have no open files when running the `codegate version` command, otherwise Copilot will make comments based on the file you have open.
+
+:::
+
 <ThemedImage
   alt='Verify Copilot integration'
   sources={{

--- a/docs/quickstart-copilot.mdx
+++ b/docs/quickstart-copilot.mdx
@@ -97,6 +97,16 @@ Add the following settings to your configuration:
 Enter `codegate version` in the Copilot chat to confirm that CodeGate is
 intercepting Copilot traffic. CodeGate responds with its version number.
 
+:::note
+
+There is a [known issue](https://github.com/stacklok/codegate/issues/1061) with
+`codegate` commands in Copilot chat if you have a file included in the context.
+Close all open files or use the eye icon in the chat input to disable the
+current file context, otherwise Copilot responds based on the file you have open
+instead of returning the command result.
+
+:::
+
 ## Explore CodeGate's key features
 
 To learn more about CodeGate's capabilities, clone the demo repository to a


### PR DESCRIPTION
If you have a file open, when running `codegate version`, you get a response based on the file and not the codegate version itself. I've added a note to inform users that they close all files before running the command. Outside of this PR, we may want to decide if this is desired functionality by Copilot or Codegate and if the version should be returned regardless if a file is currently open or not.