### PR TITLE
Mark avante integration as unlisted

### DIFF
--- a/docs/integrations/avante.mdx
+++ b/docs/integrations/avante.mdx
@@ -3,6 +3,7 @@ title: Use CodeGate with avante.nvim
 description: Configure the `avante.nvim` plugin for Neovim
 sidebar_label: avante.nvim
 sidebar_position: 15
+unlisted: true
 ---
 
 **[avante.nvim](https://github.com/yetone/avante.nvim)** is a Neovim plugin that


### PR DESCRIPTION
The support for avante.nvim hasn't shipped in a release yet, so this marks the page as unlisted.

It will still be available at https://docs.codegate.ai/integrations/avante but is hidden from navigation.

Revert this after the next release.