### PR TITLE
Re-list and update avante.nvim docs

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -13,6 +13,12 @@ Major features and changes are noted here. To review all updates, see the
 
 Related: [Upgrade CodeGate](../how-to/install.md#upgrade-codegate)
 
+- **New integration: Open Interpreter** - 20 Feb, 2025\
+  CodeGate v0.1.24 adds support for the
+  [avante.nvim](https://github.com/yetone/avante.nvim) plugin for NeoVim with
+  OpenAI and CodeGate muxing. See the
+  [integration guide](../integrations/avante.mdx) to get started.
+
 - **Muxing filter rules** - 18 Feb, 2025\
   CodeGate v0.1.23 adds filter rules for model muxing, allowing you to define
   which model should be used for a given file type. See the

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -15,7 +15,7 @@ Related: [Upgrade CodeGate](../how-to/install.md#upgrade-codegate)
 
 - **New integration: Open Interpreter** - 20 Feb, 2025\
   CodeGate v0.1.24 adds support for the
-  [avante.nvim](https://github.com/yetone/avante.nvim) plugin for NeoVim with
+  [avante.nvim](https://github.com/yetone/avante.nvim) plugin for Neovim with
   OpenAI and CodeGate muxing. See the
   [integration guide](../integrations/avante.mdx) to get started.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,8 @@ AI coding assistants / IDEs:
 
 - **[Aider](./integrations/aider.mdx)** with Ollama and OpenAI-compatible APIs
 
+- **[avante.nvim](./integrations/avante.mdx)** (NeoVim plugin) with OpenAI
+
 - **[Cline](./integrations/cline.mdx)** in Visual Studio Code
 
   CodeGate supports Ollama, Anthropic, OpenAI and compatible APIs, OpenRouter,

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ AI coding assistants / IDEs:
 
 - **[Aider](./integrations/aider.mdx)** with Ollama and OpenAI-compatible APIs
 
-- **[avante.nvim](./integrations/avante.mdx)** (NeoVim plugin) with OpenAI
+- **[avante.nvim](./integrations/avante.mdx)** (Neovim plugin) with OpenAI
 
 - **[Cline](./integrations/cline.mdx)** in Visual Studio Code
 

--- a/docs/integrations/avante.mdx
+++ b/docs/integrations/avante.mdx
@@ -106,9 +106,18 @@ To verify your setup:
 1. In Neovim, type `:AvanteChat` to launch the Avante interface.
 2. Enter the following prompt in the chat:
    ```
-   codegate version
+   add a variable AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
    ```
-3. You should receive a response like like "CodeGate version 0.1.24".
+3. The response should indicate that CodeGate redacted the secret, and an alert
+   is logged in the [dashboard](http://localhost:9090).
+
+:::info Known issue
+
+`codegate` commands like `codegate version` are not currently working with
+avante.nvim. We are
+[tracking this issue here](https://github.com/stacklok/codegate-ui/issues/346).
+
+:::
 
 ## Next steps
 

--- a/docs/integrations/avante.mdx
+++ b/docs/integrations/avante.mdx
@@ -115,7 +115,7 @@ To verify your setup:
 
 `codegate` commands like `codegate version` are not currently working with
 avante.nvim. We are
-[tracking this issue here](https://github.com/stacklok/codegate/issues/1149).
+[tracking this issue here](https://github.com/stacklok/codegate/issues/1061).
 
 :::
 

--- a/docs/integrations/avante.mdx
+++ b/docs/integrations/avante.mdx
@@ -115,7 +115,7 @@ To verify your setup:
 
 `codegate` commands like `codegate version` are not currently working with
 avante.nvim. We are
-[tracking this issue here](https://github.com/stacklok/codegate-ui/issues/346).
+[tracking this issue here](https://github.com/stacklok/codegate/issues/1149).
 
 :::
 

--- a/docs/integrations/avante.mdx
+++ b/docs/integrations/avante.mdx
@@ -19,7 +19,7 @@ provider and model using [workspaces](../features/workspaces.mdx).
 
 ## Install avante.nvim
 
-Install the `avante.nvim` plugin using your preferred NeoVim plugin manager. For
+Install the `avante.nvim` plugin using your preferred Neovim plugin manager. For
 detailed installation instructions, refer to `avante.nvim`'s
 [documentation](https://github.com/yetone/avante.nvim?tab=readme-ov-file#installation).
 
@@ -29,7 +29,7 @@ Configure `avante.nvim` to route requests through CodeGate by setting its
 provider endpoint to `http://localhost:8989/<provider>`.
 
 Using [lazy.nvim](https://lazy.folke.io/) (recommended), configure the
-`avante.nvim` provider as shown:
+`avante.nvim` provider settings as shown:
 
 <Tabs groupId="provider" queryString="provider">
 <TabItem value="mux" label="CodeGate muxing" default>
@@ -95,12 +95,12 @@ have to configure your FIM completion plugin separately.
 
 To verify your setup:
 
-1. Type `:AvanteChat` to launch the `avante.nvim `interface
-2. Enter the following command in the chat:
+1. In Neovim, type `:AvanteChat` to launch the `avante.nvim `interface.
+2. Enter the following prompt in the chat:
    ```
    codegate version
    ```
-3. You should receive a response showing the current CodeGate version number
+3. You should receive a response like like "CodeGate version 0.1.24".
 
 ## Next steps
 

--- a/docs/integrations/avante.mdx
+++ b/docs/integrations/avante.mdx
@@ -5,75 +5,104 @@ sidebar_label: avante.nvim
 sidebar_position: 15
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 **[avante.nvim](https://github.com/yetone/avante.nvim)** is a Neovim plugin that
-provides a Cursor-like user experience. It integrates with multiple AI providers
-(e.g. Claude and OpenAI).
+provides a Cursor-like user experience with multiple AI providers.
+
+CodeGate works with [OpenAI](https://openai.com/api/) and compatible APIs
+through Avante.
+
+You can also use [CodeGate muxing](../features/muxing.mdx) to select your
+provider and model using [workspaces](../features/workspaces.mdx).
 
 ## Install avante.nvim
 
-Install the **avante.nvim** plugin using your preferred plugin manager. For
-instructions, consult **avante.nvim**'s
+Install the `avante.nvim` plugin using your preferred NeoVim plugin manager. For
+detailed installation instructions, refer to `avante.nvim`'s
 [documentation](https://github.com/yetone/avante.nvim?tab=readme-ov-file#installation).
 
-## Configure CodeGate with avante.nvim
+## Configure avante.nvim to use CodeGate
 
-Consult **avante.nvim**'s documentation for specific examples on customizing
-your configuration using your preferred plugin manager.
+Configure `avante.nvim` to route requests through CodeGate by setting its
+provider endpoint to `http://localhost:8989/<provider>`.
 
-Using `lazy.nvim` (recommended) add the following configuration to enable
-CodeGate with **avante.nvim**:
+Using [lazy.nvim](https://lazy.folke.io/) (recommended), configure the
+`avante.nvim` provider as shown:
 
-```lua
+<Tabs groupId="provider" queryString="provider">
+<TabItem value="mux" label="CodeGate muxing" default>
+First, configure your [provider(s)](../features/muxing.mdx#add-a-provider) and
+select a model for each of your
+[workspace(s)](../features/workspaces.mdx#manage-workspaces) in the CodeGate dashboard.
+
+Then configure `avante.nvim` to use the CodeGate mux endpoint:
+
+```lua title="~/.config/nvim/lua/plugins/avante.lua"
 {
-    "yetone/avante.nvim",
-    -- ... etc ...
-    opts = {
-      -- your provider configuration ...
-      provider = "openai",
-      openai = {
-        endpoint = "http://localhost:8989/openai", -- use the endpoint matching your LLM provider
-        model = "gpt-4o", -- your desired model (or use gpt-4o, etc.)
-        timeout = 30000, -- timeout in milliseconds
-        temperature = 0, -- adjust if needed
-        max_tokens = 4096,
-      },
+  "yetone/avante.nvim",
+  -- ... etc ...
+  opts = {
+    provider = "openai",
+    openai = {
+      endpoint = "http://localhost:8989/v1/mux", -- CodeGate's mux endpoint
+      model = "gpt-4o", -- the actual model is determined by your CodeGate workspace
+      timeout = 30000, -- timeout in milliseconds
+      temperature = 0, -- adjust if needed
+      max_tokens = 4096,
     },
-    -- ... etc ...
+  },
+  -- ... etc ...
 }
 ```
 
+</TabItem>
+<TabItem value="openai" label="OpenAI">
+You need an [OpenAI API](https://openai.com/api/) account to use this provider.
+To use a different OpenAI-compatible endpoint, set the `CODEGATE_OPENAI_URL`
+[configuration parameter](../how-to/configure.md) when you launch CodeGate.
+
+```lua title="~/.config/nvim/lua/plugins/avante.lua"
+{
+  "yetone/avante.nvim",
+  -- ... etc ...
+  opts = {
+    provider = "openai",
+    openai = {
+      endpoint = "http://localhost:8989/openai", -- CodeGate's OpenAI endpoint
+      model = "gpt-4o", -- your desired model
+      timeout = 30000, -- timeout in milliseconds
+      temperature = 0, -- adjust if needed
+      max_tokens = 4096,
+    },
+  },
+  -- ... etc ...
+}
+```
+
+</TabItem>
+</Tabs>
+
 :::note
 
-**avante.nvim** does not yet support _fill-in-the-middle_ completions. You have
-to configure your fill-in-the-middle completion plugin separately.
+`avante.nvim` does not yet support _fill-in-the-middle_ (FIM) completions. You
+have to configure your FIM completion plugin separately.
 
 :::
 
-### Verifying configuration
+## Verify configuration
 
-To verify the configuration, type `:AvanteChat` to start the **avante.nvim**
-plugin. You should see the **avante.nvim** UI appear in the Neovim window.
+To verify your setup:
 
-Type and send the following message:
+1. Type `:AvanteChat` to launch the `avante.nvim `interface
+2. Enter the following command in the chat:
+   ```
+   codegate version
+   ```
+3. You should receive a response showing the current CodeGate version number
 
-```
-codegate version
-```
+## Next steps
 
-If CodeGate is configured correctly, you should see a response from the CodeGate
-server.
-
-### Model muxing
-
-To take advantage of CodeGate's [model muxing feature](../features/muxing.mdx),
-use **avante.nvim**'s OpenAI provider with the following configuration:
-
-```lua
-openai = {
-  endpoint = "http://localhost:8989/v1/mux", -- CodeGate's mux endpoint
-  model = "gpt-4o", -- the actual model is determined by your CodeGate workspace
-  timeout = 30000, -- timeout in milliseconds
-  temperature = 0, -- adjust if needed
-  max_tokens = 4096,
-},
-```
+Learn more about [CodeGate's features](../features/index.mdx) and explore the
+[dashboard](../how-to/dashboard.md).

--- a/docs/integrations/avante.mdx
+++ b/docs/integrations/avante.mdx
@@ -20,8 +20,16 @@ provider and model using [workspaces](../features/workspaces.mdx).
 ## Install avante.nvim
 
 Install the `avante.nvim` plugin using your preferred Neovim plugin manager. For
-detailed installation instructions, refer to `avante.nvim`'s
+detailed installation instructions, refer to Avante's
 [documentation](https://github.com/yetone/avante.nvim?tab=readme-ov-file#installation).
+
+:::tip
+
+You can also install [codegate.nvim](https://github.com/stacklok/codegate.nvim),
+a plugin that interfaces with CodeGate and allows you to quickly switch between
+workspaces without leaving Neovim.
+
+:::
 
 ## Configure avante.nvim to use CodeGate
 
@@ -95,7 +103,7 @@ have to configure your FIM completion plugin separately.
 
 To verify your setup:
 
-1. In Neovim, type `:AvanteChat` to launch the `avante.nvim `interface.
+1. In Neovim, type `:AvanteChat` to launch the Avante interface.
 2. Enter the following prompt in the chat:
    ```
    codegate version

--- a/docs/integrations/avante.mdx
+++ b/docs/integrations/avante.mdx
@@ -3,7 +3,6 @@ title: Use CodeGate with avante.nvim
 description: Configure the `avante.nvim` plugin for Neovim
 sidebar_label: avante.nvim
 sidebar_position: 15
-unlisted: true
 ---
 
 **[avante.nvim](https://github.com/yetone/avante.nvim)** is a Neovim plugin that


### PR DESCRIPTION
Since v0.1.24 is out now, re-listing the avante.nvim integration doc.

Also updated it to follow the same pattern as the other integration docs.