### PR TITLE
Add Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "Docusaurus",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22-bookworm",
+  "features": {},
+  "forwardPorts": [3000],
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "unifiedjs.vscode-mdx",
+        "esbenp.prettier-vscode",
+        "davidanson.vscode-markdownlint",
+        "redhat.vscode-yaml",
+        "yzhang.markdown-all-in-one"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CodeGate docs <!-- omit in toc -->
 
+[![GitHub deployments](https://img.shields.io/github/deployments/stacklok/codegate-docs/Production?logo=vercel&style=flat&label=Vercel%20deployment)](https://github.com/stacklok/codegate-docs/deployments/Production)
+
 This repository contains the public-facing docs for CodeGate, hosted at
 [https://docs.codegate.ai](https://docs.codegate.ai).
 
@@ -19,6 +21,12 @@ Please review the [style guide](./STYLE-GUIDE.md) for help with voice, tone, and
 formatting.
 
 ## Local development
+
+You'll need Node.js available (v22 recommended) or VS Code with the
+[Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+extension and Docker.
+
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/stacklok/codegate-docs)
 
 ```bash
 npm install

--- a/docs/integrations/copilot.mdx
+++ b/docs/integrations/copilot.mdx
@@ -276,6 +276,29 @@ Here is an example of how to use the `requests` package:
 ...
 ```
 
+## Troubleshooting
+
+<details>
+  <summary>**Issue**: Copilot in VS Code does not work with Dev Containers</summary>
+
+**Details:** The Copilot extensions load within the Dev Container context by
+default, but the container cannot reach the CodeGate proxy directly and does not
+trust the CodeGate certificate.
+
+**Solution:** The simplest solution which doesn't require modifications to the
+devcontainer configuration in your project is to force the Copilot extensions to
+run in the UI context instead of remotely. Add the following to your **VS Code
+User Settings** file:
+
+```json title="settings.json"
+  "remote.extensionKind": {
+    "GitHub.copilot": ["ui"],
+    "GitHub.copilot-chat": ["ui"]
+  }
+```
+
+</details>
+
 ## Next steps
 
 Learn more about CodeGate's features and how to use them:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",
     "serve": "docusaurus serve",
-    "start": "docusaurus start",
+    "start": "docusaurus start --host 0.0.0.0",
     "swizzle": "docusaurus swizzle",
     "typecheck": "tsc",
     "write-heading-ids": "docusaurus write-heading-ids",


### PR DESCRIPTION
Adds a Dev Container config for the docs.

Also adds a troubleshooting note for CodeGate + Copilot + Dev Containers that I ran across while working on this.