### PR TITLE
Replace secrets encryption with redaction

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -31,7 +31,7 @@ Related: [Upgrade CodeGate](../how-to/install.mdx#upgrade-codegate)
 - **PII redaction:** - 10 Feb, 2025\
   Starting with v0.1.18, CodeGate now redacts personally identifiable
   information (PII) found in LLM prompts and context. See the
-  [feature page](../features/secrets-encryption.md) to learn more.
+  [feature page](../features/secrets-redaction.md) to learn more.
 
 - **Model muxing** - 7 Feb, 2025\
   With CodeGate v0.1.17 you can use the new `/v1/mux` endpoint to configure

--- a/docs/features/secrets-redaction.md
+++ b/docs/features/secrets-redaction.md
@@ -27,8 +27,7 @@ anonymizing PII. These changes are made before the prompt is sent to the LLM and
 are restored when the result is returned to your machine.
 
 When a secret or PII is detected, CodeGate adds a message to the LLM's output
-and an alert is recorded in the [dashboard](../how-to/dashboard.md) (PII alerts
-in the dashboard are coming soon).
+and an alert is recorded in the [dashboard](../how-to/dashboard.md).
 
 :::info
 

--- a/docs/features/secrets-redaction.md
+++ b/docs/features/secrets-redaction.md
@@ -1,5 +1,5 @@
 ---
-title: Secrets encryption and PII redaction
+title: Secrets and PII redaction
 description: Keep your secrets a secret
 ---
 
@@ -22,7 +22,7 @@ and PII found in your prompts.
 
 CodeGate automatically scans all prompts for secrets and PII. This happens
 transparently without requiring a specific prompt. Without interrupting your
-development flow, CodeGate protects your data by encrypting secrets and
+development flow, CodeGate protects your data by redacting secrets and
 anonymizing PII. These changes are made before the prompt is sent to the LLM and
 are restored when the result is returned to your machine.
 
@@ -55,36 +55,32 @@ sequenceDiagram
     deactivate CodeGate
 ```
 
-### Secrets encryption
+CodeGate redacts secrets and anonymizes PII by replacing each string with a
+unique identifier on the fly, before sending the prompt to the LLM. This way,
+CodeGate protects your sensitive data without blocking your development flow.
+When the LLM returns a response, CodeGate matches up the identifier and replaces
+it with the original value.
 
-CodeGate uses pattern matching to detect secrets such as:
+### Secrets filtering
+
+CodeGate uses pattern matching to detect secrets like:
 
 - API keys and tokens
-- Private keys and certificates
-- Database credentials
-- SSH keys
 - Cloud provider credentials
-- ...and more - see the
-  [signatures file](https://github.com/stacklok/codegate/blob/main/signatures.yaml)
-  in the project repo
+- Database credentials
+- Private keys and certificates
+- SSH keys
 
-CodeGate transparently encrypts secrets before sending the prompt to the LLM.
-This is performed on the fly using AES256-GCM encryption with a temporary
-per-session key. When the LLM returns a response, CodeGate decrypts the secret
-before delivering it to your coding assistant, then securely erases the
-temporary key from memory.
+For the full list of detected patterns, see the
+[signatures file](https://github.com/stacklok/codegate/blob/main/signatures.yaml)
+in the project repo.
 
 ### PII redaction
 
-CodeGate scans for common types of PII like:
+CodeGate scans for common types of PII including:
 
 - Email addresses
 - Phone numbers
 - Government identification numbers
 - Credit card numbers
 - Bank accounts and crypto wallet IDs
-
-CodeGate anonymizes PII by replacing each string with a unique identifier before
-sending the prompt to the LLM. This way, CodeGate protects your sensitive data
-without blocking your development flow. When the LLM returns a response,
-CodeGate matches up the identifier and replaces it with the original value.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,9 +36,8 @@ sequenceDiagram
 CodeGate includes several key features for privacy, security, and coding
 efficiency, including:
 
-- [Secrets encryption and PII redaction](./features/secrets-encryption.md) to
-  protect your sensitive credentials and anonymize personally identifiable
-  information
+- [Secrets PII redaction](./features/secrets-redaction.md) to protect your
+  sensitive credentials and anonymize personally identifiable information
 - [Dependency risk awareness](./features/dependency-risk.md) to update the LLM's
   knowledge of malicious or deprecated open source packages
 - [Model muxing](./features/muxing.mdx) to quickly select the best LLM
@@ -104,7 +103,7 @@ Review the [installation instructions](./how-to/install.mdx).
 
 Learn more about CodeGate's features:
 
-- [Secrets and PII redaction](./features/secrets-encryption.md)
+- [Secrets and PII redaction](./features/secrets-redaction.md)
 - [Dependency risk awareness](./features/dependency-risk.md)
 - [Security reviews](./features/security-reviews.md)
 - [Workspaces](./features/workspaces.mdx)

--- a/docs/quickstart-continue.mdx
+++ b/docs/quickstart-continue.mdx
@@ -184,7 +184,7 @@ For example, using `conf.ini`:
 @conf.ini Explain this file
 ```
 
-CodeGate intercepts the request and transparently encrypts the sensitive data
+CodeGate intercepts the request and transparently redacts the sensitive data
 before it leaves your machine.
 
 <ThemedImage
@@ -200,7 +200,7 @@ before it leaves your machine.
   width={'600px'}
 />
 
-Learn more in [Secrets encryption](./features/secrets-encryption.md).
+Learn more in [Secrets and PII redaction](./features/secrets-redaction.md).
 
 ### Assess dependency risk
 

--- a/docs/quickstart-copilot.mdx
+++ b/docs/quickstart-copilot.mdx
@@ -161,7 +161,7 @@ Enter this prompt into the chat:
 Explain the current file
 ```
 
-CodeGate intercepts the request and transparently encrypts the sensitive data
+CodeGate intercepts the request and transparently redacts the sensitive data
 before it leaves your machine.
 
 <ThemedImage
@@ -177,7 +177,7 @@ before it leaves your machine.
   width={'600px'}
 />
 
-Learn more in [Secrets encryption](./features/secrets-encryption.md).
+Learn more in [Secrets and PII redaction](./features/secrets-redaction.md).
 
 ### Assess dependency risk
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,11 @@
       "source": "/how-to/(use-with-):path(aider|cline|continue|copilot)",
       "destination": "/integrations/:path",
       "permanent": true
+    },
+    {
+      "source": "/features/secrets-encryption",
+      "destination": "/features/secrets-redaction",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
https://github.com/stacklok/codegate/pull/1123 replaced the secrets encryption process with the same UUID-based redaction used for the PII pipeline. This updates the docs to reflect that.