### PR TITLE
Update the method for running CodeGate remotely

### DIFF
--- a/docs/how-to/configure.md
+++ b/docs/how-to/configure.md
@@ -22,15 +22,16 @@ docker run --name codegate -d -p 8989:8989 -p 9090:9090 \
 
 CodeGate supports the following parameters:
 
-| Parameter                | Default value                       | Description                                                                                |
-| :----------------------- | :---------------------------------- | :----------------------------------------------------------------------------------------- |
-| `CODEGATE_APP_LOG_LEVEL` | `WARNING`                           | Sets the logging level. Valid values: `ERROR`, `WARNING`, `INFO`, `DEBUG` (case sensitive) |
-| `CODEGATE_LOG_FORMAT`    | `TEXT`                              | Type of log formatting. Valid values: `TEXT`, `JSON` (case sensitive)                      |
-| `CODEGATE_ANTHROPIC_URL` | `https://api.anthropic.com/v1`      | Specifies the Anthropic engine API endpoint URL.                                           |
-| `CODEGATE_LM_STUDIO_URL` | `http://host.docker.internal:1234`  | Specifies the URL of your LM Studio server.                                                |
-| `CODEGATE_OLLAMA_URL`    | `http://host.docker.internal:11434` | Specifies the URL of your Ollama instance.                                                 |
-| `CODEGATE_OPENAI_URL`    | `https://api.openai.com/v1`         | Specifies the OpenAI engine API endpoint URL.                                              |
-| `CODEGATE_VLLM_URL`      | `http://localhost:8000`             | Specifies the URL of the vLLM server to use.                                               |
+| Parameter                | Default value                       | Description                                                                                                                           |
+| :----------------------- | :---------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `CODEGATE_APP_LOG_LEVEL` | `WARNING`                           | Sets the logging level. Valid values: `ERROR`, `WARNING`, `INFO`, `DEBUG` (case sensitive)                                            |
+| `CODEGATE_LOG_FORMAT`    | `TEXT`                              | Type of log formatting. Valid values: `TEXT`, `JSON` (case sensitive)                                                                 |
+| `CODEGATE_ANTHROPIC_URL` | `https://api.anthropic.com/v1`      | Specifies the Anthropic engine API endpoint URL.                                                                                      |
+| `CODEGATE_LM_STUDIO_URL` | `http://host.docker.internal:1234`  | Specifies the URL of your LM Studio server.                                                                                           |
+| `CODEGATE_OLLAMA_URL`    | `http://host.docker.internal:11434` | Specifies the URL of your Ollama instance.                                                                                            |
+| `CODEGATE_OPENAI_URL`    | `https://api.openai.com/v1`         | Specifies the OpenAI engine API endpoint URL.                                                                                         |
+| `CODEGATE_VLLM_URL`      | `http://localhost:8000`             | Specifies the URL of the vLLM server to use.                                                                                          |
+| `DASHBOARD_BASE_API_URL` | `http://localhost:8989`             | Overrides the base URL of the CodeGate API referenced by the dashboard UI (see [run CodeGate on a remote host](#run-on-remote-host)). |
 
 ## Example: Use CodeGate with a remote Ollama server
 
@@ -43,55 +44,28 @@ docker run --name codegate -d -p 8989:8989 -p 9090:9090 \
   --restart unless-stopped ghcr.io/stacklok/codegate
 ```
 
-## Run CodeGate on a remote host
+## Example: run CodeGate on a remote host {#run-on-remote-host}
 
 :::warning
 
-Keep security aspects in mind and run CodeGate only on a remote host within a
-local or otherwise secured network. CodeGate should not be run on a remote host
+For security reason,s only run CodeGate on a remote host within a local or
+otherwise secured/trusted network. CodeGate should not be run on a remote host
 that is directly accessible from the Internet!
 
 :::
 
-The CodeGate web dashboard provided in the Docker container expects the CodeGate
-API to be available on _localhost_ port 8989. Currently this is statically set
-during build time and cannot be changed with a runtime configuration parameter.
+The CodeGate web dashboard provided in the Docker container makes client-side
+API calls from your web browser, and expects the CodeGate API to be available on
+_localhost_ port 8989 by default. To run CodeGate on a different host from your
+client/browser, you can override this using the `DASHBOARD_BASE_API_URL`
+environment variable (available since CodeGate v0.1.28):
 
-Hence to run CodeGate on a remote host you need to build your own appropriately
-customized Docker container image from the CodeGate GitHub repository. Use the
-following steps as a reference and adjust them for your own setup:
+```bash {2}
+docker run --name codegate -d -p 8989:8989 -p 9090:9090 \
+  -e DASHBOARD_BASE_API_URL=http://<REMOTE_HOST>:8989 \
+  --mount type=volume,src=codegate_volume,dst=/app/codegate_volume \
+  --restart unless-stopped ghcr.io/stacklok/codegate
+```
 
-1. Clone the CodeGate GitHub repository:
-
-   ```shell
-   git clone https://github.com/stacklok/codegate.git
-   cd codegate
-   ```
-
-2. Edit `./Dockerfile` to add the `VITE_BASE_API_URL` environment variable
-   _before_ the web dashboard build step:
-
-   ```dockerfile {1-3} title="./Dockerfile"
-   # Customize the API base URL
-   ENV VITE_BASE_API_URL=http://<REMOTE_HOST>:8989
-   # End customization
-
-   # Install the webapp dependencies and build it
-   RUN npm install
-   RUN npm run build
-   ```
-
-   Replace `<REMOTE_HOST>` with the IP or DNS name of the remote host where
-   CodeGate will run.
-
-3. Build the customized Docker image on the remote host:
-
-   ```shell
-   make image-build
-   ```
-
-4. Run the customized Docker image (built locally as `codegate:latest`):
-
-   ```shell
-   docker run --name codegate -d -p 8989:8989 -p 9090:9090 -p 8990:8990 --mount type=volume,src=codegate_volume,dst=/app/codegate_volume --restart unless-stopped codegate:latest
-   ```
+Replace `<REMOTE_HOST>` with the IP or DNS name of your remote CodeGate host as
+reachable from your client / web browser.

--- a/docs/how-to/install.mdx
+++ b/docs/how-to/install.mdx
@@ -18,16 +18,6 @@ Podman, replace `docker` with `podman` in all commands.
 
 ## Run CodeGate
 
-CodeGate is primarily intended as a single-user system. There is no
-authentication when using the CodeGate API or the CodeGate web dashboard which
-are both operating over unencrypted HTTP. Hence all CodeGate components are
-supposed to bind to _localhost_ (`127.0.0.1`) and remain inaccessible from
-remote hosts.
-
-If you are an advanced user who wants to run CodeGate on a remote host in a
-secured/local network, see
-[Run CodeGate on a remote host](./configure.md#run-codegate-on-a-remote-host).
-
 ### Recommended settings
 
 To download and run CodeGate with the recommended configuration for full
@@ -58,6 +48,17 @@ application settings, see [Configure CodeGate](./configure.md)
 If you omit the persistent volume mount, your
 [workspace configurations](../features/workspaces.mdx) and prompt history are
 lost when you stop or restart CodeGate.
+
+:::
+
+:::info
+
+CodeGate is primarily intended as a single-user system. The CodeGate API and web
+dashboard operate over unencrypted HTTP and with no authentication.
+
+If you are an advanced user who want to run CodeGate on a remote host in a
+secured/local network, see
+[Run CodeGate on a remote host](./configure.md#run-on-remote-host).
 
 :::
 


### PR DESCRIPTION
New DASHBOARD_BASE_API_URL parameter added in https://github.com/stacklok/codegate/pull/1231, so building a customized image is no longer needed.

Also moved the note about this deployment method lower on the install page to de-emphasize it a bit since it's not our recommended pattern.