### PR TITLE
Refer to the issue template for adding an MCP server

### DIFF
--- a/docs/toolhive/how-to/registry.md
+++ b/docs/toolhive/how-to/registry.md
@@ -176,7 +176,7 @@ This restores the default behavior of using ToolHive's built-in registry.
 ## Contribute to the registry
 
 If you have an MCP server that you'd like to add to the ToolHive registry, you
-can [open an issue](https://github.com/stacklok/toolhive/issues) or submit a
+can [open an issue](https://github.com/stacklok/toolhive/issues/new?template=add-an-mcp-server.md) or submit a
 pull request to the ToolHive GitHub repository. The ToolHive team will review
 your submission and consider adding it to the registry.
 


### PR DESCRIPTION
This PR updates the docs to refer to the issue template dedicated for MCP registry requests.